### PR TITLE
refactor: IgnoreFilter to use regex for more comprehensive file path …

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ diffs associated with pull requests.
 - Retrieve the contents of a Pull Request's Git diff from GitHub.
 - Parse combined Git diffs into individual file diffs.
 - Filter out file diffs based on a list of ignored file extensions.
+- Comprehensive regex-based file path matching for filtering file diffs.
+- Robust and extensive unit testing to ensure reliability and functionality.
 
 ## Installation
 


### PR DESCRIPTION
### Title: Enhance File Filtering and Testing in Diff Parsing Library

---

#### Overview
This PR introduces significant enhancements to file filtering in the Git diff parsing library, along with comprehensive updates to unit testing.

#### Changes
- Added regex-based file path matching (`matchIgnoreFilter` and `matchFile` functions) for more precise filtering of file diffs.
- Replaced the `slices` package with `regexp` in `github_diff.go` for advanced pattern matching.
- Expanded unit tests to cover new filtering logic and various edge cases.

#### Motivation
The enhancements were implemented to provide more flexible and accurate file filtering capabilities in the library, catering to complex use cases. The switch to regex offers better control over which files are considered in diffs. The extended unit tests ensure the reliability and robustness of the new features.

#### Testing
- New unit tests were added to validate the behavior of `matchIgnoreFilter` and `matchFile` functions against diverse file patterns and scenarios.
- Tested the filtering logic against various real-world Git diffs to ensure accuracy and performance.

#### Impact
These updates significantly improve the library's utility in projects with complex file structures, enhancing both the usability and accuracy of the diff parsing process.

---

Feedback on the implementation or suggestions for further improvements are welcome.
